### PR TITLE
Predefined rules specific source/destination_address_prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,8 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_port_ranges          = "${split(",", replace(  "${lookup(var.predefined_rules[count.index], "source_port_range", "*" )}"  ,  "*" , "0-65535" ) )}"
   destination_port_range      = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 4)}"
   description                 = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 5)}"
-  source_address_prefix       = "${lookup(var.predefined_rules[count.index], "source_address_prefix", join(",", var.source_address_prefix))}"
-  destination_address_prefix  = "${lookup(var.predefined_rules[count.index], "destination_address_prefix", join(",", var.destination_address_prefix))}"
+  source_address_prefix       = "${join(",",lookup(var.predefined_rules[count.index], "source_address_prefix",  var.source_address_prefix))}"
+  destination_address_prefix  = "${join(",",lookup(var.predefined_rules[count.index], "destination_address_prefix",  var.destination_address_prefix))}"
   resource_group_name         = "${azurerm_resource_group.nsg.name}"
   network_security_group_name = "${azurerm_network_security_group.nsg.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,8 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_port_ranges          = "${split(",", replace(  "${lookup(var.predefined_rules[count.index], "source_port_range", "*" )}"  ,  "*" , "0-65535" ) )}"
   destination_port_range      = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 4)}"
   description                 = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 5)}"
-  source_address_prefix       = "${join(",", var.source_address_prefix)}"
-  destination_address_prefix  = "${join(",", var.destination_address_prefix)}"
+  source_address_prefix       = "${lookup(var.predefined_rules[count.index], "source_address_prefix", join(",", var.source_address_prefix))}"
+  destination_address_prefix  = "${lookup(var.predefined_rules[count.index], "destination_address_prefix", join(",", var.destination_address_prefix))}"
   resource_group_name         = "${azurerm_resource_group.nsg.name}"
   network_security_group_name = "${azurerm_network_security_group.nsg.name}"
 }


### PR DESCRIPTION
Ref to issue: https://github.com/Azure/terraform-azurerm-network-security-group/issues/36
Readme Example shows that the predefined rules could specific the source/destination_address_prefix