### PR TITLE
Make resource group creation optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "azurerm_resource_group" "nsg" {
+  count    = var.resource_group_create ? 1 : 0
   name     = var.resource_group_name
   location = var.location
 }
@@ -6,7 +7,7 @@ resource "azurerm_resource_group" "nsg" {
 resource "azurerm_network_security_group" "nsg" {
   name                = var.security_group_name
   location            = var.location
-  resource_group_name = azurerm_resource_group.nsg.name
+  resource_group_name = var.resource_group_name
   tags                = var.tags
 }
 
@@ -26,7 +27,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   description                 = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 5)
   source_address_prefix       = join(",", var.source_address_prefix)
   destination_address_prefix  = join(",", var.destination_address_prefix)
-  resource_group_name         = azurerm_resource_group.nsg.name
+  resource_group_name         = var.resource_group_name
   network_security_group_name = azurerm_network_security_group.nsg.name
 }
 
@@ -46,6 +47,6 @@ resource "azurerm_network_security_rule" "custom_rules" {
   source_address_prefix       = lookup(var.custom_rules[count.index], "source_address_prefix", "*")
   destination_address_prefix  = lookup(var.custom_rules[count.index], "destination_address_prefix", "*")
   description                 = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")
-  resource_group_name         = azurerm_resource_group.nsg.name
+  resource_group_name         = var.resource_group_name
   network_security_group_name = azurerm_network_security_group.nsg.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@ variable "resource_group_name" {
   description = "Name of the resource group"
 }
 
+variable "resource_group_create" {
+  default     = true
+  description = "Set to false if your resource group already exists"
+}
+
 variable "location" {}
 
 variable "security_group_name" {


### PR DESCRIPTION
Allows for the resource group creation to be optional, in the event the resource group already exists. Defaults to true so that existing usage and tests don't fail.