### PR TITLE
Fix for issue#58

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_port_ranges                         = split(",", replace(lookup(var.predefined_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_range                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 4)
   description                                = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 5)
-  source_address_prefix                      = length(lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])) == 0 ? join(",", var.source_address_prefix) : ""
-  destination_address_prefix                 = length(lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? join(",", var.destination_address_prefix) : ""
+  source_address_prefix                      = length(lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "source_address_prefix", "*") : ""
+  destination_address_prefix                 = length(lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "destination_address_prefix", "*") : ""
   resource_group_name                        = data.azurerm_resource_group.nsg.name
   network_security_group_name                = azurerm_network_security_group.nsg.name
   source_application_security_group_ids      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])

--- a/main.tf
+++ b/main.tf
@@ -23,12 +23,14 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_port_ranges                         = split(",", replace(lookup(var.predefined_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_range                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 4)
   description                                = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 5)
-  source_address_prefix                      = length(lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "source_address_prefix", "*") : ""
-  destination_address_prefix                 = length(lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "destination_address_prefix", "*") : ""
+  source_address_prefix                      = length(lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])) == 0 && length(lookup(var.predefined_rules[count.index], "source_address_prefixes", [])) == 0 ? lookup(var.predefined_rules[count.index], "source_address_prefix", "*") : null
+  destination_address_prefix                 = length(lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])) == 0 && length(lookup(var.predefined_rules[count.index], "destination_address_prefixes", [])) == 0 ? lookup(var.predefined_rules[count.index], "destination_address_prefix", "*") : null
+  source_address_prefixes                    = length(lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "source_address_prefixes", null) : null
+  destination_address_prefixes               = length(lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? lookup(var.predefined_rules[count.index], "destination_address_prefixes", null) : null
   resource_group_name                        = data.azurerm_resource_group.nsg.name
   network_security_group_name                = azurerm_network_security_group.nsg.name
-  source_application_security_group_ids      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", [])
-  destination_application_security_group_ids = lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", [])
+  source_application_security_group_ids      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", null)
+  destination_application_security_group_ids = lookup(var.predefined_rules[count.index], "destination_application_security_group_ids", null)
 }
 
 #############################
@@ -44,11 +46,13 @@ resource "azurerm_network_security_rule" "custom_rules" {
   protocol                                   = lookup(var.custom_rules[count.index], "protocol", "*")
   source_port_ranges                         = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_ranges                    = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
-  source_address_prefix                      = length(lookup(var.custom_rules[count.index], "source_application_security_group_ids", [])) == 0 ? lookup(var.custom_rules[count.index], "source_address_prefix", "*") : ""
-  destination_address_prefix                 = length(lookup(var.custom_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? lookup(var.custom_rules[count.index], "destination_address_prefix", "*") : ""
+  source_address_prefix                      = length(lookup(var.custom_rules[count.index], "source_application_security_group_ids", [])) == 0 && length(lookup(var.custom_rules[count.index], "source_address_prefixes", [])) == 0 ? lookup(var.custom_rules[count.index], "source_address_prefix", "*") : null
+  destination_address_prefix                 = length(lookup(var.custom_rules[count.index], "destination_application_security_group_ids", [])) == 0 && length(lookup(var.custom_rules[count.index], "destination_address_prefixes", [])) == 0 ? lookup(var.custom_rules[count.index], "destination_address_prefix", "*") : null
+  source_address_prefixes                    = length(lookup(var.custom_rules[count.index], "source_application_security_group_ids", [])) == 0 ? lookup(var.custom_rules[count.index], "source_address_prefixes", null) : null
+  destination_address_prefixes               = length(lookup(var.custom_rules[count.index], "destination_application_security_group_ids", [])) == 0 ? lookup(var.custom_rules[count.index], "destination_address_prefixes", null) : null
   description                                = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")
   resource_group_name                        = data.azurerm_resource_group.nsg.name
   network_security_group_name                = azurerm_network_security_group.nsg.name
-  source_application_security_group_ids      = lookup(var.custom_rules[count.index], "source_application_security_group_ids", [])
-  destination_application_security_group_ids = lookup(var.custom_rules[count.index], "destination_application_security_group_ids", [])
+  source_application_security_group_ids      = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null)
+  destination_application_security_group_ids = lookup(var.custom_rules[count.index], "destination_application_security_group_ids", null)
 }


### PR DESCRIPTION
For the predefined rules, the `source_address_prefix` and `destination_address_prefix` were ignored in the specific rules, and overwritten by the `source_address_prefix` and `destination_address_prefix` of the module.