### PR TITLE
Azure portal recommendation on the rules detail screen

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,8 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   direction                                  = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 0)
   access                                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 1)
   protocol                                   = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 2)
-  source_port_ranges                         = split(",", lookup(var.predefined_rules[count.index], "source_port_range", "*"))
+  source_port_range                          = lookup(var.predefined_rules[count.index], "source_port_range", null ) == null ? "*" : null
+  source_port_ranges                         = lookup(var.predefined_rules[count.index], "source_port_range", null ) != null ? split(",", var.predefined_rules[count.index].source_port_range) : null
   destination_port_range                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 4)
   description                                = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 5)
   source_address_prefix                      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", null) == null && var.source_address_prefixes == null ? join(",", var.source_address_prefix) : null
@@ -44,7 +45,8 @@ resource "azurerm_network_security_rule" "custom_rules" {
   direction                                  = lookup(var.custom_rules[count.index], "direction", "Any")
   access                                     = lookup(var.custom_rules[count.index], "access", "Allow")
   protocol                                   = lookup(var.custom_rules[count.index], "protocol", "*")
-  source_port_ranges                         = split(",", lookup(var.custom_rules[count.index], "source_port_range", "*"))
+  source_port_range                          = lookup(var.custom_rules[count.index], "source_port_range", null ) == null ? "*" : null
+  source_port_ranges                         = lookup(var.custom_rules[count.index], "source_port_range", null ) != null ? split(",", var.custom_rules[count.index].source_port_range) : null
   destination_port_ranges                    = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
   source_address_prefix                      = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null) == null && lookup(var.custom_rules[count.index], "source_address_prefixes", null) == null ? lookup(var.custom_rules[count.index], "source_address_prefix", "*") : null
   source_address_prefixes                    = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null) == null ? lookup(var.custom_rules[count.index], "source_address_prefixes", null) : null

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   direction                                  = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 0)
   access                                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 1)
   protocol                                   = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 2)
-  source_port_ranges                         = split(",", replace(lookup(var.predefined_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
+  source_port_ranges                         = split(",", lookup(var.predefined_rules[count.index], "source_port_range", "*"))
   destination_port_range                     = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 4)
   description                                = element(var.rules[lookup(var.predefined_rules[count.index], "name")], 5)
   source_address_prefix                      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", null) == null && var.source_address_prefixes == null ? join(",", var.source_address_prefix) : null
@@ -44,7 +44,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   direction                                  = lookup(var.custom_rules[count.index], "direction", "Any")
   access                                     = lookup(var.custom_rules[count.index], "access", "Allow")
   protocol                                   = lookup(var.custom_rules[count.index], "protocol", "*")
-  source_port_ranges                         = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
+  source_port_ranges                         = split(",", lookup(var.custom_rules[count.index], "source_port_range", "*"))
   destination_port_ranges                    = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
   source_address_prefix                      = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null) == null && lookup(var.custom_rules[count.index], "source_address_prefixes", null) == null ? lookup(var.custom_rules[count.index], "source_address_prefix", "*") : null
   source_address_prefixes                    = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null) == null ? lookup(var.custom_rules[count.index], "source_address_prefixes", null) : null


### PR DESCRIPTION
The azure portal shows an alert if port-range 0-65535 is used instead of *

"The recommended value for source port ranges is * (Any). Port filtering is mainly used with destination port."


