### PR TITLE
Fix direction at custom rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   count                                      = length(var.custom_rules)
   name                                       = lookup(var.custom_rules[count.index], "name", "default_rule_name")
   priority                                   = lookup(var.custom_rules[count.index], "priority")
-  direction                                  = lookup(var.custom_rules[count.index], "direction", "Any")
+  direction                                  = lookup(var.custom_rules[count.index], "direction", "Inbound")
   access                                     = lookup(var.custom_rules[count.index], "access", "Allow")
   protocol                                   = lookup(var.custom_rules[count.index], "protocol", "*")
   source_port_range                          = lookup(var.custom_rules[count.index], "source_port_range", "*") == "*" ? "*" : null


### PR DESCRIPTION
Fixing `direction` at resource `azurerm_network_security_rule` to use default `Inbound` as default option.

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network-security-group .
$ docker run --rm azure-network-security-group /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #73 

Changes proposed in the pull request:
Changing logic on custom rules, where direction is set to `Any`. When you try to leave all default settings, terraform returns that it was expecting `Inbound` or `Outbound` and received `Any`. Therefore, I set Inbound as default rule.


