### PR TITLE
fix: change incorrect protocol casing

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -8,118 +8,118 @@ variable "rules" {
     #ActiveDirectory
     ActiveDirectory-AllowADReplication          = ["Inbound", "Allow", "*", "*", "389", "AllowADReplication"]
     ActiveDirectory-AllowADReplicationSSL       = ["Inbound", "Allow", "*", "*", "636", "AllowADReplicationSSL"]
-    ActiveDirectory-AllowADGCReplication        = ["Inbound", "Allow", "TCP", "*", "3268", "AllowADGCReplication"]
-    ActiveDirectory-AllowADGCReplicationSSL     = ["Inbound", "Allow", "TCP", "*", "3269", "AllowADGCReplicationSSL"]
+    ActiveDirectory-AllowADGCReplication        = ["Inbound", "Allow", "Tcp", "*", "3268", "AllowADGCReplication"]
+    ActiveDirectory-AllowADGCReplicationSSL     = ["Inbound", "Allow", "Tcp", "*", "3269", "AllowADGCReplicationSSL"]
     ActiveDirectory-AllowDNS                    = ["Inbound", "Allow", "*", "*", "53", "AllowDNS"]
     ActiveDirectory-AllowKerberosAuthentication = ["Inbound", "Allow", "*", "*", "88", "AllowKerberosAuthentication"]
     ActiveDirectory-AllowADReplicationTrust     = ["Inbound", "Allow", "*", "*", "445", "AllowADReplicationTrust"]
-    ActiveDirectory-AllowSMTPReplication        = ["Inbound", "Allow", "TCP", "*", "25", "AllowSMTPReplication"]
-    ActiveDirectory-AllowRPCReplication         = ["Inbound", "Allow", "TCP", "*", "135", "AllowRPCReplication"]
-    ActiveDirectory-AllowFileReplication        = ["Inbound", "Allow", "TCP", "*", "5722", "AllowFileReplication"]
-    ActiveDirectory-AllowWindowsTime            = ["Inbound", "Allow", "UDP", "*", "123", "AllowWindowsTime"]
+    ActiveDirectory-AllowSMTPReplication        = ["Inbound", "Allow", "Tcp", "*", "25", "AllowSMTPReplication"]
+    ActiveDirectory-AllowRPCReplication         = ["Inbound", "Allow", "Tcp", "*", "135", "AllowRPCReplication"]
+    ActiveDirectory-AllowFileReplication        = ["Inbound", "Allow", "Tcp", "*", "5722", "AllowFileReplication"]
+    ActiveDirectory-AllowWindowsTime            = ["Inbound", "Allow", "Udp", "*", "123", "AllowWindowsTime"]
     ActiveDirectory-AllowPasswordChangeKerberes = ["Inbound", "Allow", "*", "*", "464", "AllowPasswordChangeKerberes"]
-    ActiveDirectory-AllowDFSGroupPolicy         = ["Inbound", "Allow", "UDP", "*", "138", "AllowDFSGroupPolicy"]
-    ActiveDirectory-AllowADDSWebServices        = ["Inbound", "Allow", "TCP", "*", "9389", "AllowADDSWebServices"]
-    ActiveDirectory-AllowNETBIOSAuthentication  = ["Inbound", "Allow", "UDP", "*", "137", "AllowNETBIOSAuthentication"]
-    ActiveDirectory-AllowNETBIOSReplication     = ["Inbound", "Allow", "TCP", "*", "139", "AllowNETBIOSReplication"]
+    ActiveDirectory-AllowDFSGroupPolicy         = ["Inbound", "Allow", "Udp", "*", "138", "AllowDFSGroupPolicy"]
+    ActiveDirectory-AllowADDSWebServices        = ["Inbound", "Allow", "Tcp", "*", "9389", "AllowADDSWebServices"]
+    ActiveDirectory-AllowNETBIOSAuthentication  = ["Inbound", "Allow", "Udp", "*", "137", "AllowNETBIOSAuthentication"]
+    ActiveDirectory-AllowNETBIOSReplication     = ["Inbound", "Allow", "Tcp", "*", "139", "AllowNETBIOSReplication"]
 
     #Cassandra
-    Cassandra = ["Inbound", "Allow", "TCP", "*", "9042", "Cassandra"]
+    Cassandra = ["Inbound", "Allow", "Tcp", "*", "9042", "Cassandra"]
 
     #Cassandra-JMX
-    Cassandra-JMX = ["Inbound", "Allow", "TCP", "*", "7199", "Cassandra-JMX"]
+    Cassandra-JMX = ["Inbound", "Allow", "Tcp", "*", "7199", "Cassandra-JMX"]
 
     #Cassandra-Thrift
-    Cassandra-Thrift = ["Inbound", "Allow", "TCP", "*", "9160", "Cassandra-Thrift"]
+    Cassandra-Thrift = ["Inbound", "Allow", "Tcp", "*", "9160", "Cassandra-Thrift"]
 
     #CouchDB
-    CouchDB = ["Inbound", "Allow", "TCP", "*", "5984", "CouchDB"]
+    CouchDB = ["Inbound", "Allow", "Tcp", "*", "5984", "CouchDB"]
 
     #CouchDB-HTTPS
-    CouchDB-HTTPS = ["Inbound", "Allow", "TCP", "*", "6984", "CouchDB-HTTPS"]
+    CouchDB-HTTPS = ["Inbound", "Allow", "Tcp", "*", "6984", "CouchDB-HTTPS"]
 
     #DNS-TCP
-    DNS-TCP = ["Inbound", "Allow", "TCP", "*", "53", "DNS-TCP"]
+    DNS-TCP = ["Inbound", "Allow", "Tcp", "*", "53", "DNS-TCP"]
 
     #DNS-UDP
-    DNS-UDP = ["Inbound", "Allow", "UDP", "*", "53", "DNS-UDP"]
+    DNS-UDP = ["Inbound", "Allow", "Udp", "*", "53", "DNS-UDP"]
 
     #DynamicPorts
-    DynamicPorts = ["Inbound", "Allow", "TCP", "*", "49152-65535", "DynamicPorts"]
+    DynamicPorts = ["Inbound", "Allow", "Tcp", "*", "49152-65535", "DynamicPorts"]
 
     #ElasticSearch
-    ElasticSearch = ["Inbound", "Allow", "TCP", "*", "9200-9300", "ElasticSearch"]
+    ElasticSearch = ["Inbound", "Allow", "Tcp", "*", "9200-9300", "ElasticSearch"]
 
     #FTP
-    FTP = ["Inbound", "Allow", "TCP", "*", "21", "FTP"]
+    FTP = ["Inbound", "Allow", "Tcp", "*", "21", "FTP"]
 
     #HTTP
-    HTTP = ["Inbound", "Allow", "TCP", "*", "80", "HTTP"]
+    HTTP = ["Inbound", "Allow", "Tcp", "*", "80", "HTTP"]
 
     #HTTPS
-    HTTPS = ["Inbound", "Allow", "TCP", "*", "443", "HTTPS"]
+    HTTPS = ["Inbound", "Allow", "Tcp", "*", "443", "HTTPS"]
 
     #IMAP
-    IMAP = ["Inbound", "Allow", "TCP", "*", "143", "IMAP"]
+    IMAP = ["Inbound", "Allow", "Tcp", "*", "143", "IMAP"]
 
     #IMAPS
-    IMAPS = ["Inbound", "Allow", "TCP", "*", "993", "IMAPS"]
+    IMAPS = ["Inbound", "Allow", "Tcp", "*", "993", "IMAPS"]
 
     #Kestrel
-    Kestrel = ["Inbound", "Allow", "TCP", "*", "22133", "Kestrel"]
+    Kestrel = ["Inbound", "Allow", "Tcp", "*", "22133", "Kestrel"]
 
     #LDAP
-    LDAP = ["Inbound", "Allow", "TCP", "*", "389", "LDAP"]
+    LDAP = ["Inbound", "Allow", "Tcp", "*", "389", "LDAP"]
 
     #MongoDB
-    MongoDB = ["Inbound", "Allow", "TCP", "*", "27017", "MongoDB"]
+    MongoDB = ["Inbound", "Allow", "Tcp", "*", "27017", "MongoDB"]
 
     #Memcached
-    Memcached = ["Inbound", "Allow", "TCP", "*", "11211", "Memcached"]
+    Memcached = ["Inbound", "Allow", "Tcp", "*", "11211", "Memcached"]
 
     #MSSQL
-    MSSQL = ["Inbound", "Allow", "TCP", "*", "1433", "MSSQL"]
+    MSSQL = ["Inbound", "Allow", "Tcp", "*", "1433", "MSSQL"]
 
     #MySQL
-    MySQL = ["Inbound", "Allow", "TCP", "*", "3306", "MySQL"]
+    MySQL = ["Inbound", "Allow", "Tcp", "*", "3306", "MySQL"]
 
     #Neo4J
-    Neo4J = ["Inbound", "Allow", "TCP", "*", "7474", "Neo4J"]
+    Neo4J = ["Inbound", "Allow", "Tcp", "*", "7474", "Neo4J"]
 
     #POP3
-    POP3 = ["Inbound", "Allow", "TCP", "*", "110", "POP3"]
+    POP3 = ["Inbound", "Allow", "Tcp", "*", "110", "POP3"]
 
     #POP3S
-    POP3S = ["Inbound", "Allow", "TCP", "*", "995", "POP3S"]
+    POP3S = ["Inbound", "Allow", "Tcp", "*", "995", "POP3S"]
 
     #PostgreSQL
-    PostgreSQL = ["Inbound", "Allow", "TCP", "*", "5432", "PostgreSQL"]
+    PostgreSQL = ["Inbound", "Allow", "Tcp", "*", "5432", "PostgreSQL"]
 
     #RabbitMQ
-    RabbitMQ = ["Inbound", "Allow", "TCP", "*", "5672", "RabbitMQ"]
+    RabbitMQ = ["Inbound", "Allow", "Tcp", "*", "5672", "RabbitMQ"]
 
     #RDP
-    RDP = ["Inbound", "Allow", "TCP", "*", "3389", "RDP"]
+    RDP = ["Inbound", "Allow", "Tcp", "*", "3389", "RDP"]
 
     #Redis
-    Redis = ["Inbound", "Allow", "TCP", "*", "6379", "Redis"]
+    Redis = ["Inbound", "Allow", "Tcp", "*", "6379", "Redis"]
 
     #Riak
-    Riak = ["Inbound", "Allow", "TCP", "*", "8093", "Riak"]
+    Riak = ["Inbound", "Allow", "Tcp", "*", "8093", "Riak"]
 
     #Riak-JMX
-    Riak-JMX = ["Inbound", "Allow", "TCP", "*", "8985", "Riak-JMX"]
+    Riak-JMX = ["Inbound", "Allow", "Tcp", "*", "8985", "Riak-JMX"]
 
     #SMTP
-    SMTP = ["Inbound", "Allow", "TCP", "*", "25", "SMTP"]
+    SMTP = ["Inbound", "Allow", "Tcp", "*", "25", "SMTP"]
 
     #SMTPS
-    SMTPS = ["Inbound", "Allow", "TCP", "*", "465", "SMTPS"]
+    SMTPS = ["Inbound", "Allow", "Tcp", "*", "465", "SMTPS"]
 
     #SSH
-    SSH = ["Inbound", "Allow", "TCP", "*", "22", "SSH"]
+    SSH = ["Inbound", "Allow", "Tcp", "*", "22", "SSH"]
 
     #WinRM
-    WinRM = ["Inbound", "Allow", "TCP", "*", "5986", "WinRM"]
+    WinRM = ["Inbound", "Allow", "Tcp", "*", "5986", "WinRM"]
   }
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network-security-group .
$ docker run --rm azure-network-security-group /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #76  

Changes proposed in the pull request: "TCP" -> "Tcp", "UDP" -> "Udp" in `rules.tf`

I wasn't able to create a NSG, because of the error:

```
Error: expected protocol to be one of [* Tcp Udp Icmp Ah Esp], got TCP
```

It seems that in [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm) the following line got removed somewhere between version [v2.99.0](https://github.com/hashicorp/terraform-provider-azurerm/blob/v2.99.0/internal/services/network/network_security_group_resource.go#L85) and the current [one](https://github.com/hashicorp/terraform-provider-azurerm/blob/v3.28.0/internal/services/network/network_security_group_resource.go#L83):

```go
DiffSuppressFunc: suppress.CaseDifferenceV2Only,
```

Because of that this module cannot create `azurerm_network_security_rule` resources - `protocol` is case sensitive now.