### PR TITLE
Add random string to test resource group name so we can run tests in parallel

### DIFF
--- a/examples/ActiveDirectory/main.tf
+++ b/examples/ActiveDirectory/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/ActiveDirectory/providers.tf
+++ b/examples/ActiveDirectory/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Cassandra-JMX/main.tf
+++ b/examples/Cassandra-JMX/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Cassandra-JMX/providers.tf
+++ b/examples/Cassandra-JMX/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Cassandra-Thrift/main.tf
+++ b/examples/Cassandra-Thrift/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Cassandra-Thrift/providers.tf
+++ b/examples/Cassandra-Thrift/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Cassandra/main.tf
+++ b/examples/Cassandra/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Cassandra/providers.tf
+++ b/examples/Cassandra/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/CouchDB-HTTPS/main.tf
+++ b/examples/CouchDB-HTTPS/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/CouchDB-HTTPS/providers.tf
+++ b/examples/CouchDB-HTTPS/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/CouchDB/main.tf
+++ b/examples/CouchDB/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/CouchDB/providers.tf
+++ b/examples/CouchDB/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/DNS-TCP/main.tf
+++ b/examples/DNS-TCP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/DNS-TCP/providers.tf
+++ b/examples/DNS-TCP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/DNS-UDP/main.tf
+++ b/examples/DNS-UDP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/DNS-UDP/providers.tf
+++ b/examples/DNS-UDP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/DynamicPorts/main.tf
+++ b/examples/DynamicPorts/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/DynamicPorts/providers.tf
+++ b/examples/DynamicPorts/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/ElasticSearch/main.tf
+++ b/examples/ElasticSearch/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/ElasticSearch/providers.tf
+++ b/examples/ElasticSearch/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/FTP/main.tf
+++ b/examples/FTP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/FTP/providers.tf
+++ b/examples/FTP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/HTTP/main.tf
+++ b/examples/HTTP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/HTTP/providers.tf
+++ b/examples/HTTP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/HTTPS/main.tf
+++ b/examples/HTTPS/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/HTTPS/providers.tf
+++ b/examples/HTTPS/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/IMAP/main.tf
+++ b/examples/IMAP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/IMAP/providers.tf
+++ b/examples/IMAP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/IMAPS/main.tf
+++ b/examples/IMAPS/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/IMAPS/providers.tf
+++ b/examples/IMAPS/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Kestrel/main.tf
+++ b/examples/Kestrel/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Kestrel/providers.tf
+++ b/examples/Kestrel/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/LDAP/main.tf
+++ b/examples/LDAP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/LDAP/providers.tf
+++ b/examples/LDAP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/MSSQL/main.tf
+++ b/examples/MSSQL/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/MSSQL/providers.tf
+++ b/examples/MSSQL/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Memcached/main.tf
+++ b/examples/Memcached/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Memcached/providers.tf
+++ b/examples/Memcached/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/MongoDB/main.tf
+++ b/examples/MongoDB/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/MongoDB/providers.tf
+++ b/examples/MongoDB/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/MySQL/main.tf
+++ b/examples/MySQL/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/MySQL/providers.tf
+++ b/examples/MySQL/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Neo4J/main.tf
+++ b/examples/Neo4J/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Neo4J/providers.tf
+++ b/examples/Neo4J/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/POP3/main.tf
+++ b/examples/POP3/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/POP3/providers.tf
+++ b/examples/POP3/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/POP3S/main.tf
+++ b/examples/POP3S/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/POP3S/providers.tf
+++ b/examples/POP3S/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/PostgreSQL/main.tf
+++ b/examples/PostgreSQL/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/PostgreSQL/providers.tf
+++ b/examples/PostgreSQL/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/RDP/main.tf
+++ b/examples/RDP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/RDP/providers.tf
+++ b/examples/RDP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/RabbitMQ/main.tf
+++ b/examples/RabbitMQ/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/RabbitMQ/providers.tf
+++ b/examples/RabbitMQ/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Redis/main.tf
+++ b/examples/Redis/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Redis/providers.tf
+++ b/examples/Redis/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Riak-JMX/main.tf
+++ b/examples/Riak-JMX/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Riak-JMX/providers.tf
+++ b/examples/Riak-JMX/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/Riak/main.tf
+++ b/examples/Riak/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/Riak/providers.tf
+++ b/examples/Riak/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/SMTP/main.tf
+++ b/examples/SMTP/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/SMTP/providers.tf
+++ b/examples/SMTP/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/SMTPS/main.tf
+++ b/examples/SMTPS/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/SMTPS/providers.tf
+++ b/examples/SMTPS/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/SSH/main.tf
+++ b/examples/SSH/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/SSH/providers.tf
+++ b/examples/SSH/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/examples/WinRM/main.tf
+++ b/examples/WinRM/main.tf
@@ -1,6 +1,12 @@
+resource "random_string" "postfix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "azurerm_resource_group" "nsg_rg" {
   location = var.location
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}${random_string.postfix.result}"
 }
 
 module "nsg" {

--- a/examples/WinRM/providers.tf
+++ b/examples/WinRM/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.11.0, < 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 


### PR DESCRIPTION
The test resource groups' names in this module's examples are the same -- `nsg_rg`, if we'd like to run the tests in parallel we'll have naming conflict. This pr added a random string as resource group name's postfix to solve this issue.

## Describe your changes

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

