### PR TITLE
Capture the iterator variable to avoid concurrent test error

### DIFF
--- a/test/e2e/terraform_network_security_group_test.go
+++ b/test/e2e/terraform_network_security_group_test.go
@@ -18,11 +18,12 @@ func TestExamples(t *testing.T) {
 	}
 
 	for _, d := range directories {
-		if strings.HasPrefix(d.Name(), "_") || !d.IsDir() {
+		directory := d
+		if strings.HasPrefix(directory.Name(), "_") || !directory.IsDir() {
 			continue
 		}
-		t.Run(d.Name(), func(t *testing.T) {
-			test_helper.RunE2ETest(t, "../../", fmt.Sprintf("examples/%s", d.Name()), terraform.Options{
+		t.Run(directory.Name(), func(t *testing.T) {
+			test_helper.RunE2ETest(t, "../../", fmt.Sprintf("examples/%s", directory.Name()), terraform.Options{
 				Upgrade: true,
 			}, func(t *testing.T, output test_helper.TerraformOutput) {
 				nsgId, ok := output["network_security_group_id"].(string)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -24,10 +24,11 @@ func TestUpgrade(t *testing.T) {
 		t.FailNow()
 	}
 	for _, d := range directories {
-		if strings.HasPrefix(d.Name(), "_") || strings.Contains(d.Name(), "test") || !d.IsDir() {
+		directory := d
+		if strings.HasPrefix(directory.Name(), "_") || strings.Contains(directory.Name(), "test") || !directory.IsDir() {
 			continue
 		}
-		t.Run(d.Name(), func(t *testing.T) {
+		t.Run(directory.Name(), func(t *testing.T) {
 			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-network-security-group", fmt.Sprintf("examples/%s", d.Name()), currentRoot, terraform.Options{
 				Upgrade: true,
 			}, currentMajorVersion)


### PR DESCRIPTION
## Describe your changes

We have a classic `foreach` error in our go test code, it would cause randomly error when we try to execute tests concurrently, this pull request capture the iterator variable into a local variable to avoid such error.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

