### PR TITLE
support space inside source_port_range

### DIFF
--- a/examples/_template/providers.tf
+++ b/examples/_template/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=1.2"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.11.0, < 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_address_prefixes                    = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", null) == null ? var.source_address_prefixes : null
   source_application_security_group_ids      = lookup(var.predefined_rules[count.index], "source_application_security_group_ids", null)
   source_port_range                          = lookup(var.predefined_rules[count.index], "source_port_range", "*") == "*" ? "*" : null
-  source_port_ranges                         = lookup(var.predefined_rules[count.index], "source_port_range", "*") == "*" ? null : split(",", var.predefined_rules[count.index].source_port_range)
+  source_port_ranges                         = lookup(var.predefined_rules[count.index], "source_port_range", "*") == "*" ? null : [for p in split(",", var.predefined_rules[count.index].source_port_range) : trimspace(p)]
 }
 
 resource "azurerm_network_security_rule" "predefined_rules_for" {
@@ -54,7 +54,7 @@ resource "azurerm_network_security_rule" "predefined_rules_for" {
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? var.source_address_prefixes : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null
-  source_port_ranges                         = lookup(each.value, "source_port_range", "*") == "*" ? null : split(",", each.value.source_port_range)
+  source_port_ranges                         = lookup(each.value, "source_port_range", "*") == "*" ? null : [for r in split(",", each.value.source_port_range) : trimspace(r)]
 
   lifecycle {
     precondition {
@@ -87,7 +87,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   source_address_prefixes                    = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null) == null ? lookup(var.custom_rules[count.index], "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null)
   source_port_range                          = lookup(var.custom_rules[count.index], "source_port_range", "*") == "*" ? "*" : null
-  source_port_ranges                         = lookup(var.custom_rules[count.index], "source_port_range", "*") == "*" ? null : split(",", var.custom_rules[count.index].source_port_range)
+  source_port_ranges                         = lookup(var.custom_rules[count.index], "source_port_range", "*") == "*" ? null : [for r in split(",", var.custom_rules[count.index].source_port_range) : trimspace(r)]
 
   lifecycle {
     precondition {
@@ -116,7 +116,7 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? lookup(each.value, "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null
-  source_port_ranges                         = lookup(each.value, "source_port_range", "*") == "*" ? null : split(",", each.value.source_port_range)
+  source_port_ranges                         = lookup(each.value, "source_port_range", "*") == "*" ? null : [for r in split(",", each.value.source_port_range) : trimspace(r)]
 
   lifecycle {
     precondition {


### PR DESCRIPTION
## Describe your changes

As #66 described:

>Using this module, because of the split function in main.tf lines 47 & 48 on source_port_range and destination_port_range, a list of ports must be declared "portA,portB", without any space or brackets.

This pr improves usability by trimming space from the split port.

## Issue number

#66

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

